### PR TITLE
Fix Issue #23 - Change Filesize to Int or Null

### DIFF
--- a/js/web-crawler.bundle.js
+++ b/js/web-crawler.bundle.js
@@ -18376,7 +18376,7 @@ function startRequestListeners() {
 		    	originUrl: assetOriginUrl,
 		    	adNetworkUrl: assetAdHost,
 		    	assetType: details.type,
-		    	fileSize: assetSize || "-",
+		    	fileSize: assetSize || null,
 		    	timeStamp: details.timeStamp,
 		    	method: details.method,
 		    	statusCode: details.statusCode,

--- a/web-crawler.js
+++ b/web-crawler.js
@@ -63,7 +63,7 @@ function startRequestListeners() {
 		    	originUrl: assetOriginUrl,
 		    	adNetworkUrl: assetAdHost,
 		    	assetType: details.type,
-		    	fileSize: assetSize || "-",
+		    	fileSize: assetSize || null,
 		    	timeStamp: details.timeStamp,
 		    	method: details.method,
 		    	statusCode: details.statusCode,


### PR DESCRIPTION
Per #23 we want to save filesize without any strings (previously setting "-" when filesize wasn't given to us in response header). Now we are setting filesize to Null if we aren't given it.
