### PR TITLE
Fix #23 - Log fileSize as Int not String

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .git
 .eslintrc.js
 data/resultLogs.txt
+/.idea/**

--- a/web-crawler.js
+++ b/web-crawler.js
@@ -62,7 +62,7 @@ function startRequestListeners() {
 		    	originUrl: assetOriginUrl,
 		    	adNetworkUrl: assetAdHost,
 		    	assetType: details.type,
-		    	fileSize: assetSize || null,
+		    	fileSize: parseInt(assetSize) || null,
 		    	timeStamp: details.timeStamp,
 		    	method: details.method,
 		    	statusCode: details.statusCode,


### PR DESCRIPTION
- Trying to fix #23 better by parseInt-ing assetSize instead of sending it as String. 
- .gitignore - ignoring webstorm IDE files (!!optionally include in merge!!)
