### PR TITLE
Enhance profiler tool, styling, copy

### DIFF
--- a/js/profiler.js
+++ b/js/profiler.js
@@ -7,7 +7,13 @@ document.addEventListener('DOMContentLoaded', function() {
 	var adCount = document.getElementById('adNum');
 	var adSizeCount = document.getElementById('adFile');
 	var adWaitCount = document.getElementById('adLoad');
-	var newTable;
+	var tip = document.getElementById('tip');
+	var outputArea = document.getElementById('outputArea');
+	var copyButton = document.getElementById('copyJSON');
+	var numLabel = document.getElementById('numLabel');
+	var fileLabel = document.getElementById('fileLabel');
+	var loadLabel = document.getElementById('loadLabel');
+	var errorDisplayed = false;
 
 	// check to see if we are currently profiling
 	chrome.runtime.sendMessage({ "profileCheck": true }, function (response) {
@@ -16,34 +22,40 @@ document.addEventListener('DOMContentLoaded', function() {
 		// if we are profiling
 		if(profiling) {
 			// add the stop button and "recording" text
-			stopButton.style.display = "block";
-			recordingMessage.style.display = "block";
+			stopButton.classList.remove("hidden");
+			recordingMessage.classList.remove("hidden");
 
 			// remove the start button
-			startButton.style.display = "none";
-
-			// set the table header string locally
-		    newTable = "<table id=\"#userData\"><tr><th align=\"left\">Website</th><th align=\"left\">Ad Network</th><th align=\"left\">File Type</th><th align=\"left\">File Size</th><th align=\"left\">Load Time</th></tr>";
+			startButton.classList.add("hidden");
+			tip.classList.add("hidden");
 		}
 	});
 
 	// ad our start-button click listener
 	startButton.addEventListener('click', function (event) {
-		// remove the start button
-		startButton.style.display = "none";
-
 		// add the stop button and "recording" text
-		stopButton.style.display = "block";
-		recordingMessage.style.display = "block";
+		stopButton.classList.remove("hidden");
+		recordingMessage.classList.remove("hidden");
+
+		// hide everything that may not have been hidden already
+		outputArea.classList.add("hidden");
+		copyButton.classList.add("hidden");
+		numLabel.classList.add("hidden");
+		fileLabel.classList.add("hidden");
+		loadLabel.classList.add("hidden");
+		startButton.classList.add("hidden");
+		tip.classList.add("hidden");
+
+		if (errorDisplayed) {
+			var errorMessage = document.getElementById('errorMsg');
+			errorMessage.classList.add("hidden");
+			errorDisplayed = false;
+		}
 
 		// remove any previous records which might still exist in the DOM
 		adSizeCount.innerHTML = "";
 	    adWaitCount.innerHTML = "";
 	    adCount.innerHTML = "";
-	    userDataTable.innerHTML = "";
-
-	    // reset the local table string
-	    newTable = "<table id=\"#userData\"><tr><th align=\"left\">Website</th><th align=\"left\">Ad Network</th><th align=\"left\">File Type</th><th align=\"left\">File Size</th><th align=\"left\">Load Time</th></tr>";
 
 	    // start profiling
 		chrome.runtime.sendMessage({ profiling: true});
@@ -52,63 +64,105 @@ document.addEventListener('DOMContentLoaded', function() {
 	// add our stop-button click listener
 	stopButton.addEventListener('click', function (event) {
 		// add the start button
-		startButton.style.display = "block";
+		startButton.classList.remove("hidden");
 
 		// remove the stop button and "recording" text
-		stopButton.style.display = "none";
-		recordingMessage.style.display = "none";
+		stopButton.classList.add("hidden");
+		recordingMessage.classList.add("hidden");
 
 		// stop profiling
 		chrome.runtime.sendMessage({ profiling: false}, function (response) {
 			// now that we've stopped profiling and recieved a response confirming that
 
 			// if we've got benchmarks to display		
-			if(typeof response.profiles !== 'undefined')  {
+			if(typeof response.profiles !== 'undefined' && response.profiles !== "{\"assets\":]}")  {
 				// initialize our benchmark counts
 				var totalFileSize = 0;
 				var totalWaitTime = 0;
+				var totalAssetCount = 0;
+
+				// put the JSON in our textarea
+			    outputArea.textContent = response.profiles;
+
+			    // unhide all our stat labels and output area + copy button
+			   	outputArea.classList.remove("hidden");
+				copyButton.classList.remove("hidden");
+				numLabel.classList.remove("hidden");
+				fileLabel.classList.remove("hidden");
+				loadLabel.classList.remove("hidden");
 
 				// initialize our local benchmark data store
-	            var profileBenchmarks = JSON.parse(response.profiles);
-	            var profileBenchmarks = profileBenchmarks.assets;
-
-	            // set the total ad count in the DOM
-	            adCount.innerHTML = "<p id=\"adNum\"><b>Assets Benchmarked: </b> " + Object.keys(profileBenchmarks).length + "</p>";
+	            var profileBenchmarks = JSON.parse(response.profiles).assets;
 
 	            // iterate through our benchmark storage
 	            for (var record in profileBenchmarks) {
 	            	// if the record is of non-zero file size
-	                if(profileBenchmarks[record]["fileSize"]) {
+	            	if(profileBenchmarks[record]["fileSize"]) {
 	                	// record our benchmark counts
 	                	totalFileSize += profileBenchmarks[record]["fileSize"];
-	                	totalWaitTime += profileBenchmarks[record]["assetCompleteTime"];
-
-	                	// and add the asset to our table
-	                    newTable += "<tr><td>" + escapeHTML(profileBenchmarks[record]["hostUrl"]) + "</td>";
-	                    newTable += "<td>" + escapeHTML(profileBenchmarks[record]["adNetwork"]) + "</td>";
-	                    newTable += "<td>" + escapeHTML(profileBenchmarks[record]["assetType"]) + "</td>";
-	                    newTable += "<td>" + (((parseInt(profileBenchmarks[record]["fileSize"])/1024) >= 1) ? (Math.round(parseInt(profileBenchmarks[record]["fileSize"])/1024)) + " kb" : parseInt(profileBenchmarks[record]["fileSize"]) + " bytes") + "</td>";
-	                    newTable += "<td>" + ((parseInt(profileBenchmarks[record]["assetCompleteTime"])/1000 >= 1) ?  (Math.round(parseInt(profileBenchmarks[record]["assetCompleteTime"])/1000)) + " s" : parseInt(profileBenchmarks[record]["assetCompleteTime"]) + " ms") + "</td></tr>";
-	                }
-	            }
+						totalWaitTime += profileBenchmarks[record]["assetCompleteTime"];
+					}
+	            }  
 
 	            // calculate our benchmark counts based upon standard units of measurement
-	            totalFileSize = (((totalFileSize/1024) >= 1) ? (Math.round(totalFileSize/1024)) + " kb" : totalFileSize + " bytes");
-	            totalWaitTime = ((totalWaitTime/1000 >= 1) ?  (Math.round(totalWaitTime/1000)) + " seconds" : totalWaitTime + " milliseconds");
+	            totalAssetCount = (Object.keys(profileBenchmarks).length || 0);
+	            totalFileSize = formatBytes(totalFileSize);
+	            totalWaitTime = formatMillseconds(totalWaitTime);
 
 	            // add bechmark counts to the DOM
-	            adSizeCount.innerHTML = "<p id=\"adFile\"><b>Memory Used on Ads: </b> " + totalFileSize + "</p>";
-	            adWaitCount.innerHTML = "<p id=\"adLoad\"><b>Network Time Spent on Ads: </b> " + totalWaitTime + "</p>";
-
-	            // close the table
-	            newTable += "</table>";
-
-	            // add the table to the DOM
-	            userDataTable.innerHTML = newTable;
-	        }
+	            adCount.innerHTML = "<p id=\"adNum\">" + totalAssetCount + "</p>";
+	            adSizeCount.innerHTML = "<p id=\"adFile\">" + (totalFileSize || 0) + "</p>";
+	            adWaitCount.innerHTML = "<p id=\"adLoad\">" + (totalWaitTime || 0) + "</p>";
+	        } else if (!errorDisplayed) {
+		        startButton.insertAdjacentHTML("afterend", "<span class=\"label label-danger\" id=\"errorMsg\">Uh, oh, we didn't find any Ads.</span>");
+		       	errorDisplayed = true;
+		    }
 	    });
 	});
+
+	copyButton.addEventListener("click", function (event) {
+		outputArea.select();
+		var result = document.execCommand('copy');
+
+		if (result) {
+			copyButton.insertAdjacentHTML("afterend", "<br><span class=\"label label-success\">Successfully copied!</span>");
+			copyButton.disabled = true;
+		} else {
+			copyButton.insertAdjacentHTML("afterend", "<br><span class=\"label label-danger\">Copy Unsuccessful :( " + result+ "</span>");
+		}
+	});
 });
+
+function formatBytes (bytes, decimals) {
+    if (bytes === 0) {
+        return '0 Bytes';
+    }
+
+    var k = 1024;
+    var dm = decimals || 3;
+    var sizes = ['bytes', 'kb', 'mb', 'gb', 'tb', 'pm', 'eb', 'zb', 'yb'];
+    var i = Math.floor(Math.log(bytes) / Math.log(k));
+
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+}
+
+function formatMillseconds (millisec, decimals) {
+    var seconds = (millisec / 1000).toFixed(decimals);
+    var minutes = (millisec / (1000 * 60)).toFixed(decimals);
+    var hours = (millisec / (1000 * 60 * 60)).toFixed(decimals);
+    var days = (millisec / (1000 * 60 * 60 * 24)).toFixed(decimals);
+
+    if (seconds < 60) {
+        return seconds + " sec";
+    } else if (minutes < 60) {
+        return minutes + " min";
+    } else if (hours < 24) {
+        return hours + " hrs";
+    } else {
+        return days + " days"
+    }
+}
+
 
 function escapeHTML(str){
 	return str.replace(/[&"'<>]/g, (m) => ({ "&": "&amp;", '"': "&quot;", "'": "&#39;", "<": "&lt;", ">": "&gt;" })[m]);

--- a/styles/userReport.css
+++ b/styles/userReport.css
@@ -1,7 +1,7 @@
 body {
 	font-family: "Helvetica";
 	width: 550px;
-	height: 500px;
+	height: 530px;
 	padding: 20px;
 }
 
@@ -83,7 +83,7 @@ body {
 }
 
 #stopProfileButton {
-	display: none;
+	display: block;
 	background-color: #2B98BD;
 	color: white;
 	font-weight: bold;
@@ -93,10 +93,6 @@ body {
 	font-size: 1em;
 	text-align: center;
 	color: grey;
-}
-
-#recordingText {
-	display: none;
 }
 
 .hidden {

--- a/views/profiler.html
+++ b/views/profiler.html
@@ -25,19 +25,29 @@
       <div class="body">
         <div class="head">
           <p class="detail-head">Performance Tool</p>
-          <p class="detail-subhead">Profile websites by recording benchmarks with the profiler tool</p>
         </div>
         <div class="options">
           <input id="startProfileButton" type="button" class="btn btn-default" value="Start Recording Ad Performance">
-          <input id="stopProfileButton" type="button" class="btn btn-info" value="Stop Recording Ad Performance">
-          <p id="recordingText">Site Sonar is recording ad-content benchmarking data</p>
+          <input id="stopProfileButton" type="button" class="btn btn-info hidden" value="Stop Recording Ad Performance">
+          <p id="recordingText" class="hidden">Site Sonar is recording ad-content benchmarking data</p>
+          <p id="tip">Profile website ad benchmarks using the performance tool. For best results, close all tabs except the one(s) you'd like to profile and start recording above.</p>
         </div>
         <div class="benchmarkOverview">
-        	<p id="adNum"></p>
-        	<p id="adFile"></p>
-        	<p id="adLoad"></p>
+          <div class="metricBox" id="main">
+            <p class="metric" id="adNum"></p>
+            <p class="subMetric hidden" id="numLabel">Ad Assets Benchmarked</p>
+          </div>
+          <div class="metricBox" id="secondary">
+            <p class="metric" id="adFile"></p>
+            <p class="subMetric hidden" id="fileLabel">Memory Used on Ads</b>
+          </div>
+          <div class="metricBox" id="secondary">
+            <p class="metric" id="adLoad"></p>
+            <p class="subMetric hidden" id="loadLabel">Network Time Spent on Ads</b>
+          </div>
         </div>
-        <table id="userData"></table>
+        <textarea id="outputArea" rows="4" cols="50" class="hidden"></textarea><br>
+        <input type="button" class="btn btn-default hidden" id="copyJSON" value="Copy to Clipboard"> </input>
       </div>
     <div>
   </body>

--- a/views/userReport.html
+++ b/views/userReport.html
@@ -23,12 +23,13 @@
       </ul>
     <div class="body">
       <div class="head">
-        <p class="detail-head">Executive Summary</p>
+        <p class="detail-head">Ad Summary</p>
+        <p class="detail-subhead">Overview of all ad assets benchmarked since install
       </div>
       <div class="benchmarkOverview">
         <div class="metricBox" id="main">
           <p class="metric" id="adNumber"></p>
-          <p class="subMetric">Assets Benchmarked</p>
+          <p class="subMetric">Ad Assets Benchmarked</p>
         </div>
         <div class="metricBox" id="secondary">
           <p class="metric" id="adFileSize"></p>


### PR DESCRIPTION
Hey @purukaushik, I wanted to get this final stuff in before the code freeze. Its a pretty huge enhancement to the profiler tool so that the output doesn't look like crap. People can now export their profile data just like they can export all their browser data in the export tool. Also it gives them a summary like the overview page, but only for the time period they were recording.

I'm going to try to merge this ASAP so we can get it pushed to AMO+Chrome Store+Opera Store, so I may self review on Github and then you can review post-merge.
